### PR TITLE
upgrade to coffee2 to fix inheritance issue

### DIFF
--- a/collections2.coffee
+++ b/collections2.coffee
@@ -18,8 +18,8 @@ Set::map = (fn) ->
 exports.Map2 = class Map2 extends require 'map2'
   constructor: (data) ->
     if typeof data is 'function'
-      @default = data
       super()
+      @default = data
     else
       super data
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "set2": "^1.0.0"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^2.7.0",
     "mersenne": "^0.0.3",
     "mocha": "^3.0.2"
   },


### PR DESCRIPTION
This fixes an issue where inheriting from Map2 in collections.coffee causes a
"cannot call Map2 constructor without 'new' keyword" error when map2 is
compiled to use es6 native class support, which it is on npm (see
https://unpkg.com/map2@1.1.2/map2.js).

coffee2 uses native "class" syntax so this inheritance works correctly w/
coffee2.
